### PR TITLE
Remove pkg-resources==0.0.0 dependency, seems to not exist ?

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,6 @@ parso==0.6.1
 pexpect==4.8.0
 pickleshare==0.7.5
 Pillow==7.0.0
-pkg-resources==0.0.0
 prompt-toolkit==3.0.3
 ptyprocess==0.6.0
 pycurl==7.43.0.5


### PR DESCRIPTION
Makes `pip install -r requirements.txt` work.